### PR TITLE
Fixed link to downloads page

### DIFF
--- a/template/documentation.html
+++ b/template/documentation.html
@@ -2,7 +2,7 @@
 {% set documentation %}1{% end %}
 {% include template/base.html %}
     <h3>Download and Install</h3>
-    <p>see <a href="/download">download</a></p>
+    <p>see <a href="/downloads">download</a></p>
     <h3>Discussion and Mailing list</h3>
     <p>see <a href="https://groups.google.com/d/forum/lemon-lang">https://groups.google.com/d/forum/lemon-lang</a></p>
     <h3>Comments</h3>


### PR DESCRIPTION
Just a simple fix for the "download" link on the Documentation page.